### PR TITLE
Group all options inside of a 'drupal-scaffold' element.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,20 @@ of your root `composer.json`.
 ```json
 {
   "extra": {
-      "drupal-scaffold-excludes": [
+    "drupal-scaffold": {
+      "excludes": [
         "google123.html",
         "robots.txt"
       ],
-      "drupal-scaffold-excludes-omit-defaults": false,
+      "omit-defaults": false
     }
+  }
 }
 ```
 
-With `drupal-scaffold-excludes` you can provide additional paths, that should
-not be copied or overwritten. Default excludes are provided by the plugin:
+With the `drupal-scaffold` option `excludes`, you can provide additional paths 
+that should not be copied or overwritten. Default excludes are provided by the 
+plugin:
 ```
 .gitkeep
 autoload.php
@@ -44,6 +47,7 @@ profiles
 modules
 ```
 
-With setting `drupal-scaffold-excludes-omit-defaults` to `true`, those defaults
-will be ignored.  Make sure you add relevant paths back to `drupal-scaffold-excludes`
-manually, when enabling this setting.
+When setting `omit-defaults` to `true`, the defaults excludes will not be
+provided; in this instance, only those files listed in `excludes` will be
+excluded.  Make sure that the `excludes` option contains all relevant paths,
+as anything not listed here will be overwritten when using `omit-defaults`.

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "type": "composer-plugin",
     "license": "GPL-2.0+",
     "require": {
+        "php": ">=5.4.5",
         "composer-plugin-api": "^1.0.0",
         "codegyre/robo": "^0.6.0",
         "drush/drush": "*"

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -101,28 +101,37 @@ class Handler {
    * @return array
    */
   protected function getExcludes(Composer $composer) {
-    $extra = $composer->getPackage()->getExtra();
+    $options = $this->getOptions($composer);
     $excludes = array();
-    if (empty($extra['drupal-scaffold-excludes-omit-defaults'])) {
+    if (empty($options['omit-defaults'])) {
       $excludes = $this->getExcludesDefault();
     }
+    $excludes = array_merge($excludes, (array) $options['excludes']);
 
-    if (isset($extra['drupal-scaffold-excludes'])) {
-      if (is_array($extra['drupal-scaffold-excludes'])) {
-        $excludes = array_merge($excludes, $extra['drupal-scaffold-excludes']);
-      }
-      else {
-        $excludes[] = $extra['drupal-scaffold-excludes'];
-      }
-    }
     return $excludes;
+  }
+
+  /**
+   * Retrieve excludes from optional "extra" configuration.
+   *
+   * @param Composer $composer
+   *
+   * @return array
+   */
+  protected function getOptions(Composer $composer) {
+    $extra = $composer->getPackage()->getExtra() + ['drupal-scaffold' => []];
+    $options = $extra['drupal-scaffold'] + [
+      'omit-defaults' => FALSE,
+      'excludes' => [],
+    ];
+    return $options;
   }
 
   /**
    * Holds default excludes.
    */
   protected function getExcludesDefault() {
-    return array(
+    return [
       '.gitkeep',
       'autoload.php',
       'composer.json',
@@ -137,6 +146,6 @@ class Handler {
       'themes',
       'profiles',
       'modules',
-    );
+    ];
   }
 }


### PR DESCRIPTION
Per conventions for Composer plugins, places all options inside a top-level element.