### PR TITLE
Provide script callback for custom command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ command callback to the `scripts`-section of your root `composer.json`, like thi
 ```json
 {
   "scripts": {
-    "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Handler::command"
+    "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -47,7 +47,24 @@ profiles
 modules
 ```
 
-When setting `omit-defaults` to `true`, the defaults excludes will not be
+When setting `omit-defaults` to `true`, the default excludes will not be
 provided; in this instance, only those files listed in `excludes` will be
-excluded.  Make sure that the `excludes` option contains all relevant paths,
+excluded. Make sure that the `excludes` option contains all relevant paths,
 as anything not listed here will be overwritten when using `omit-defaults`.
+
+## Custom command
+
+The plugin by default is only downloading the scaffold files when installing or
+updating `drupal/core`. If you want to call it manually, you have to add the 
+command callback to the `scripts`-section of your root `composer.json`, like this:
+
+```json
+{
+  "scripts": {
+    "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Handler::command"
+  }
+}
+```
+
+After that you can manually download the scaffold files according to your
+configuration by using `composer drupal-scaffold`.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -55,7 +55,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
    * @param \Composer\Installer\PackageEvent $event
    */
   public function postPackage(PackageEvent $event) {
-    $this->handler->postPackage($event);
+    $this->handler->onPostPackageEvent($event);
   }
 
   /**
@@ -64,6 +64,16 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
    * @param \Composer\Script\Event $event
    */
   public function postCmd(\Composer\Script\Event $event) {
-    $this->handler->postCmd($event);
+    $this->handler->onPostCmdEvent($event);
+  }
+
+  /**
+   * Script callback for putting in composer scripts.
+   *
+   * @param \Composer\Script\Event $event
+   */
+  public static function scaffold(\Composer\Script\Event $event) {
+    $handler = new Handler($event->getComposer(), $event->getIO());
+    $handler->downloadScaffold();
   }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -63,7 +63,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
    *
    * @param \Composer\Script\Event $event
    */
-  public function postCmd($event) {
+  public function postCmd(\Composer\Script\Event $event) {
     $this->handler->postCmd($event);
   }
 }


### PR DESCRIPTION
With this PR, a custom callback is added, so the scaffold downloading could be triggered manually in a composer project by adding it to the scripts section:

```json
{
  "scripts": {
    "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Handler::command"
  }
}
```

@greg-1-anderson, can you review that? ;)