### PR TITLE
Scaffold command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,24 @@ profiles
 modules
 ```
 
-When setting `omit-defaults` to `true`, the defaults excludes will not be
+When setting `omit-defaults` to `true`, the default excludes will not be
 provided; in this instance, only those files listed in `excludes` will be
-excluded.  Make sure that the `excludes` option contains all relevant paths,
+excluded. Make sure that the `excludes` option contains all relevant paths,
 as anything not listed here will be overwritten when using `omit-defaults`.
+
+## Custom command
+
+The plugin by default only downloads the scaffold files when installing or
+updating `drupal/core`. If you want to call it manually, you have to add the 
+command callback to the `scripts`-section of your root `composer.json`, like this:
+
+```json
+{
+  "scripts": {
+    "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::command"
+  }
+}
+```
+
+After that you can manually download the scaffold files according to your
+configuration by using `composer drupal-scaffold`.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ command callback to the `scripts`-section of your root `composer.json`, like thi
 ```json
 {
   "scripts": {
-    "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::command"
+    "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold"
   }
 }
 ```

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -53,11 +53,10 @@ class Handler {
    * where we cached it in the $drupalCorePackage field.
    */
   protected function getDrupalCorePackage($composer) {
-    if (isset($this->drupalCorePackage)) {
-      return $this->drupalCorePackage;
+    if (!isset($this->drupalCorePackage)) {
+      $this->drupalCorePackage = $composer->getRepositoryManager()->getLocalRepository()->findPackage('drupal/core', '*');
     }
-    $package = $composer->getRepositoryManager()->getLocalRepository()->findPackage('drupal/core', '*');
-    $this->drupalCorePackage = $package;
+    return $this->drupalCorePackage;
   }
 
   /**

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -13,7 +13,7 @@ use Composer\Package\PackageInterface;
 class Handler {
 
   /**
-   * @var \Composer\IO\IOInterface
+   * @var \Composer\Package\PackageInterface
    */
   protected $drupalCorePackage;
 
@@ -37,14 +37,27 @@ class Handler {
   }
 
   /**
-   * Post command event to execute the scaffolding.
+   * Execute the scaffolding update.
    *
    * @param \Composer\Script\Event $event
    */
-  public function postCmd(\Composer\Script\Event $event) {
-    if (isset($this->drupalCorePackage)) {
-      $this->downloadScaffold($event->getComposer(), $this->drupalCorePackage);
+  public function scaffoldCmd(\Composer\Script\Event $event) {
+    $package = $this->getDrupalCorePackage($event->getComposer());
+    if ($package) {
+      $this->downloadScaffold($event->getComposer(), $package);
     }
+  }
+
+  /**
+   * Look up the Drupal core package object, or return it from
+   * where we cached it in the $drupalCorePackage field.
+   */
+  protected function getDrupalCorePackage($composer) {
+    if (isset($this->drupalCorePackage)) {
+      return $this->drupalCorePackage;
+    }
+    $package = $composer->getRepositoryManager()->getLocalRepository()->findPackage('drupal/core', '*');
+    $this->drupalCorePackage = $package;
   }
 
   /**

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -37,7 +37,19 @@ class Handler {
   }
 
   /**
-   * Execute the scaffolding update.
+   * Execute the scaffolding update after an install or update command.
+   *
+   * @param \Composer\Script\Event $event
+   */
+  public function postCmd(\Composer\Script\Event $event) {
+    $package = $this->drupalCorePackage;
+    if ($package) {
+      $this->downloadScaffold($event->getComposer(), $package);
+    }
+  }
+
+  /**
+   * Execute the scaffolding update by request.
    *
    * @param \Composer\Script\Event $event
    */

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -81,7 +81,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
   public static function scaffold(\Composer\Script\Event $event) {
     $composer = $event->getComposer();
     $plugin = static::self($composer);
-    $plugin->dispatch($event, __METHOD__);
+    $plugin->dispatch($event, __FUNCTION__);
   }
 
   /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -70,7 +70,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
    * @param \Composer\Script\Event $event
    */
   public function postCmd($event) {
-    $this->handler->scaffoldCmd($event);
+    $this->handler->postCmd($event);
   }
 
   /**


### PR DESCRIPTION
This is a continuation of #3.  I didn't like the way the static methods were proliferating. It did not matter for some of the simple methods, but if one were to imaging the complexity of a composer installer expanding, it would become increasingly inconvenient to not have access to the plugin and handler instances in command callbacks. The catch-22 here is that the command callback must be static; as more of the functionality of a Composer plugin is exposed to custom commands, more of its implementation is forced into static methods. This did not feel right.

In this PR, the plugin manager is used like a service container to recover our Plugin instance. Also introduced is a dispatching pattern that can be used to add any number of commands, as needed. Again, possibly not needed here, but I prefer the more maintainable version presented here.