### PR TITLE
Http download method

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ listed in the `excludes` and `includes` options will be considered.  If
 `omit-defaults` is `false` (the default), then any items listed in `excludes`
 or `includes` will be in addition to the usual defaults.
 
+## Limitation
+
+When using Composer to install or update the Drupal development branch, the
+scaffold files are always taken from the HEAD of the branch (or, more
+specifically, from the most recent development .tar.gz archive).  This might
+not be what you want when using an old development version (e.g. when the
+version is fixed via composer.lock).  To avoid problems, always commit your
+scaffold files to the repository any time that composer.lock is committed.
+
 ## Custom command
 
 The plugin by default is only downloading the scaffold files when installing or

--- a/README.md
+++ b/README.md
@@ -17,13 +17,12 @@ of your root `composer.json`.
 {
   "extra": {
     "drupal-scaffold": {
-      "method": "http",
       "source": "http://ftp.drupal.org/files/projects/drupal-{version}.tar.gz",
       "excludes": [
         "google123.html",
         "robots.txt"
       ],
-      "settings": [
+      "includes": [
         "sites/default/example.settings.my.php"
       ],
       "omit-defaults": false
@@ -31,10 +30,8 @@ of your root `composer.json`.
   }
 }
 ```
-The `method` setting selects how the scaffold files will be downloaded.
-Currently, `drush` and `http` are supported.  If the `http` method is selected,
-then the `source` option may be used to specify the URL to download the
-scaffold files from.  The default source is drupal.org.  The literal string
+The `source` option may be used to specify the URL to download the
+scaffold files from; the default source is drupal.org.  The literal string
 `{version}` in the `source` option is replaced with the current version of 
 Drupal core being updated prior to download.
 
@@ -58,11 +55,9 @@ profiles
 modules
 ```
 
-Usually, the `sites` folder should be excluded (this is the default); however,
-there are some settings files, such as sites/default/default.settings.php,
-which should be copied over.  Additional scaffold settings files may be
-specified with the `settings` option. Default settings are provided by the
-plugin:
+If there are some files inside of an excluded location that should be
+copied over, they can be individually selected for inclusion via the
+`includes` option.  Default includes are provided by the plugin:
 ```
 sites/default/default.settings.php
 sites/default/default.services.yml
@@ -71,11 +66,10 @@ sites/example.sites.php
 ```
 
 When setting `omit-defaults` to `true`, neither the default excludes nor the
-default setting will be provided; in this instance, only those files listed in 
-`excludes` will be excluded, and only the files listed in `settings` will be
-copied to sites/default. Make sure that the `excludes` option contains all 
-relevant paths, as anything not listed here will be overwritten when using 
-`omit-defaults`.
+default includes will be provided; in this instance, only those files explicitly
+listed in the `excludes` and `includes` options will be considered.  If
+`omit-defaults` is `false` (the default), then any items listed in `excludes`
+or `includes` will be in addition to the usual defaults.
 
 ## Custom command
 

--- a/README.md
+++ b/README.md
@@ -17,15 +17,26 @@ of your root `composer.json`.
 {
   "extra": {
     "drupal-scaffold": {
+      "method": "http",
+      "source": "http://ftp.drupal.org/files/projects/drupal-{version}.tar.gz",
       "excludes": [
         "google123.html",
         "robots.txt"
+      ],
+      "settings": [
+        "sites/default/example.settings.my.php"
       ],
       "omit-defaults": false
     }
   }
 }
 ```
+The `method` setting selects how the scaffold files will be downloaded.
+Currently, `drush` and `http` are supported.  If the `http` method is selected,
+then the `source` option may be used to specify the URL to download the
+scaffold files from.  The default source is drupal.org.  The literal string
+`{version}` in the `source` option is replaced with the current version of 
+Drupal core being updated prior to download.
 
 With the `drupal-scaffold` option `excludes`, you can provide additional paths 
 that should not be copied or overwritten. Default excludes are provided by the 
@@ -47,10 +58,24 @@ profiles
 modules
 ```
 
-When setting `omit-defaults` to `true`, the default excludes will not be
-provided; in this instance, only those files listed in `excludes` will be
-excluded. Make sure that the `excludes` option contains all relevant paths,
-as anything not listed here will be overwritten when using `omit-defaults`.
+Usually, the `sites` folder should be excluded (this is the default); however,
+there are some settings files, such as sites/default/default.settings.php,
+which should be copied over.  Additional scaffold settings files may be
+specified with the `settings` option. Default settings are provided by the
+plugin:
+```
+sites/default/default.settings.php
+sites/default/default.services.yml
+sites/example.settings.local.php
+sites/example.sites.php
+```
+
+When setting `omit-defaults` to `true`, neither the default excludes nor the
+default setting will be provided; in this instance, only those files listed in 
+`excludes` will be excluded, and only the files listed in `settings` will be
+copied to sites/default. Make sure that the `excludes` option contains all 
+relevant paths, as anything not listed here will be overwritten when using 
+`omit-defaults`.
 
 ## Custom command
 

--- a/README.md
+++ b/README.md
@@ -49,18 +49,21 @@ example.gitignore
 LICENSE.txt
 README.txt
 vendor
-sites
 themes
 profiles
 modules
+sites/*
 ```
 
 If there are some files inside of an excluded location that should be
 copied over, they can be individually selected for inclusion via the
 `includes` option.  Default includes are provided by the plugin:
 ```
+sites
+sites/default
 sites/default/default.settings.php
 sites/default/default.services.yml
+sites/development.services.yml
 sites/example.settings.local.php
 sites/example.sites.php
 ```

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,7 @@
     "require": {
         "php": ">=5.4.5",
         "composer-plugin-api": "^1.0.0",
-        "codegyre/robo": "^0.6.0",
-        "drush/drush": "*"
+        "codegyre/robo": "^0.6.0"
     },
     "autoload": {
       "psr-4": {

--- a/src/Extract.php
+++ b/src/Extract.php
@@ -1,0 +1,191 @@
+<?php
+namespace DrupalComposer\DrupalScaffold;
+
+use Robo\Result;
+use Robo\Task\BaseTask;
+
+/**
+ * Extracts an archive.
+ *
+ * ``` php
+ * <?php
+ * $this->taskExtract($archivePath)
+ *  ->to($destination)
+ *  ->run();
+ * ?>
+ * ```
+ *
+ * @method to(string) location to store extracted files
+ */
+class Extract extends BaseTask
+{
+    use \Robo\Common\DynamicParams;
+
+    protected $filename;
+    protected $to;
+
+    public function __construct($filename)
+    {
+        $this->filename = $filename;
+    }
+
+    function run()
+    {
+        if (!file_exists($this->filename)) {
+            $this->printTaskError("File {$this->filename} does not exist");
+            return false;
+        }
+
+        $text = file_get_contents($this->filename);
+        if ($this->regex) {
+            $text = preg_replace($this->regex, $this->to, $text, -1, $count);
+        } else {
+            $text = str_replace($this->from, $this->to, $text, $count);
+        }
+        if ($count > 0) {
+            $res = file_put_contents($this->filename, $text);
+            if ($res === false) {
+                return Result::error($this, "Error writing to file {$this->filename}.");
+            }
+            $this->printTaskSuccess("<info>{$this->filename}</info> updated. $count items replaced");
+        } else {
+            $this->printTaskInfo("<info>{$this->filename}</info> unchanged. $count items replaced");
+        }
+        return Result::success($this, '', ['replaced' => $count]);
+    }
+
+  function run() {
+    if (!file_exists($this->filename)) {
+      $this->printTaskError("File {$this->filename} does not exist");
+      return false;
+    }
+    if (!($mimetype = static::archiveType($this->filename))) {
+      $this->printTaskError("Could not determine type of archive for {$this->filename}");
+      return false;
+    }
+
+    // We will first extract to $extractLocation and then move to $this->to
+    $extractLocation = static::getTmpDir();
+    $this->taskFilesystemStack()
+      ->mkdir($extractLocation)
+      ->mkdir(dirname($this->to))
+      ->run();
+
+    // Perform the extraction of a zip file.
+    if (($mimetype == 'application/zip') || ($mimetype == 'application/x-zip')) {
+      $this->taskExec("unzip")
+        ->args($this->filename)
+        ->args("-d")
+        ->args("--destination=$extractLocation")
+        ->run();
+    }
+    // Otherwise we have a possibly-compressed Tar file.
+    // If we are not on Windows, then try to do "tar" in a single operation.
+    else {
+      $tar_compression_flag = '';
+      if ($mimetype == 'application/x-gzip') {
+        $tar_compression_flag = 'z';
+      }
+      elseif ($mimetype == 'application/x-bzip2') {
+        $tar_compression_flag = 'j';
+      }
+      $this->taskExec("tar")
+        ->args('-C')
+        ->args($extractLocation)
+        ->args("-x${$tar_compression_flag}f")
+        ->args($this->filename)
+        ->run();
+    }
+
+    // Now, we want to move the extracted files to $this->to. There
+    // are two possibilities that we must consider:
+    //
+    // (1) Archived files were encapsulated in a folder with an arbitrary name
+    // (2) There was no encapsulating folder, and all the files in the archive
+    //     were extracted into $extractLocation
+    //
+    // In the case of (1), we want to move and rename the encapsulating folder
+    // to $this->to.
+    //
+    // In the case of (2), we will just move and rename $extractLocation.
+    $filesInExtractLocation = glob("$extractLocation/*");
+    $hasEncapsulatingFolder = ((count($filesInExtractLocation) == 1) && is_dir($filesInExtractLocation[0]));
+    if ($hasEncapsulatingFolder) {
+      $this->taskFilesystemStack()
+        ->rename($filesInExtractLocation[0], $this->to);
+      $this->taskDeleteDir($extractLocation)->run();
+    }
+    else {
+      $this->taskFilesystemStack()
+        ->rename($extractLocation, $this->to);
+    }
+    return $return;
+  }
+
+  protected static function archiveType($archivePath) {
+    $content_type = FALSE;
+    if (class_exists('finfo')) {
+      $finfo = new finfo(FILEINFO_MIME_TYPE);
+      $content_type = $finfo->file($filename);
+      // If finfo cannot determine the content type, then we will try other methods
+      if ($content_type == 'application/octet-stream') {
+        $content_type = FALSE;
+      }
+    }
+    // Examing the file's magic header bytes.
+    if (!$content_type) {
+      if ($file = fopen($filename, 'rb')) {
+        $first = fread($file, 2);
+        fclose($file);
+
+        if ($first !== FALSE) {
+          // Interpret the two bytes as a little endian 16-bit unsigned int.
+          $data = unpack('v', $first);
+          switch ($data[1]) {
+            case 0x8b1f:
+              // First two bytes of gzip files are 0x1f, 0x8b (little-endian).
+              // See http://www.gzip.org/zlib/rfc-gzip.html#header-trailer
+              $content_type = 'application/x-gzip';
+              break;
+
+            case 0x4b50:
+              // First two bytes of zip files are 0x50, 0x4b ('PK') (little-endian).
+              // See http://en.wikipedia.org/wiki/Zip_(file_format)#File_headers
+              $content_type = 'application/zip';
+              break;
+
+            case 0x5a42:
+              // First two bytes of bzip2 files are 0x5a, 0x42 ('BZ') (big-endian).
+              // See http://en.wikipedia.org/wiki/Bzip2#File_format
+              $content_type = 'application/x-bzip2';
+              break;
+          }
+        }
+      }
+    }
+    // 3. Lastly if above methods didn't work, try to guess the mime type from
+    // the file extension. This is useful if the file has no identificable magic
+    // header bytes (for example tarballs).
+    if (!$content_type) {
+      // Remove querystring from the filename, if present.
+      $filename = basename(current(explode('?', $filename, 2)));
+      $extension_mimetype = array(
+        '.tar.gz'  => 'application/x-gzip',
+        '.tgz'     => 'application/x-gzip',
+        '.tar'     => 'application/x-tar',
+      );
+      foreach ($extension_mimetype as $extension => $ct) {
+        if (substr($filename, -strlen($extension)) === $extension) {
+          $content_type = $ct;
+          break;
+        }
+      }
+    }
+    return $content_type;
+  }
+
+  protected static function getTmpDir() {
+    return getcwd() . '/tmp' . rand() . time();
+  }
+
+}

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -94,11 +94,11 @@ class Handler {
     $extra = [];
     switch ($options['method']) {
       case 'drush':
-        $roboCommand = 'drupal_scaffold:drush_download';
+        $roboCommand = 'drupal_scaffold:drush-download';
         $extra = ['--drush', $this->getDrushDir() . '/drush'];
         break;
       case 'http':
-        $roboCommand = 'drupal_scaffold:http_download';
+        $roboCommand = 'drupal_scaffold:http-download';
         $extra = ['--source', $options['source']];
         break;
     }
@@ -165,7 +165,7 @@ class Handler {
    * @return array
    */
   protected function getExcludes() {
-    return getNamedOptionList('excludes', 'getExcludesDefault');
+    return $this->getNamedOptionList('excludes', 'getExcludesDefault');
   }
 
   /**
@@ -174,7 +174,7 @@ class Handler {
    * @return array
    */
   protected function getSettingsFiles() {
-    return getNamedOptionList('settings', 'getSettingFilesDefault');
+    return $this->getNamedOptionList('settings', 'getSettingFilesDefault');
   }
 
   /**
@@ -188,7 +188,7 @@ class Handler {
     $options = $this->getOptions($this->composer);
     $result = array();
     if (empty($options['omit-defaults'])) {
-      $result = $this->getSettingFilesDefault();
+      $result = $this->$defaultFn();
     }
     $result = array_merge($result, (array) $options[$optionName]);
 

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -252,6 +252,7 @@ class Handler {
       'profiles',
       'modules',
       'sites/*',
+      'sites/default/*'
     ];
   }
 

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -78,9 +78,9 @@ class Handler {
    * @param \Composer\Script\Event $event
    */
   public function onPostInstallCmdEvent(\Composer\Script\Event $event) {
-    // TODO: Only install the scaffolding if drupal/core was installed,
+    // Only install the scaffolding if drupal/core was installed,
     // AND there are no scaffolding files present.
-    if (isset($this->drupalCorePackage)) {
+    if (isset($this->drupalCorePackage) && !$this->checkScaffoldFiles()) {
       $this->downloadScaffold();
     }
   }
@@ -95,6 +95,31 @@ class Handler {
     if (isset($this->drupalCorePackage)) {
       $this->downloadScaffold();
     }
+  }
+
+  /**
+   * Return 'TRUE' if there are any scaffold files present.
+   *
+   * (Alternatively, rule could be to return TRUE if all
+   * of the scaffold files and directories are present, but
+   * in the case of includes with a glob pattern, this could be
+   * a problem.)
+   */
+  public function checkScaffoldFiles() {
+    $drupalCorePackage = $this->getDrupalCorePackage();
+    $installationManager = $this->composer->getInstallationManager();
+    $corePath = $installationManager->getInstallPath($drupalCorePackage);
+    // Webroot is the parent path of the drupal core installation path.
+    $webroot = dirname($corePath);
+    $includes = $this->getIncludes();
+
+    foreach ($includes as $include) {
+      if (is_file("$webroot/$include")) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
   }
 
   /**

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -77,49 +77,22 @@ class Handler {
    *
    * @param \Composer\Script\Event $event
    */
-  public function onPostInstallCmdEvent(\Composer\Script\Event $event) {
+  public function onPostCmdEvent(\Composer\Script\Event $event) {
     // Only install the scaffolding if drupal/core was installed,
     // AND there are no scaffolding files present.
-    if (isset($this->drupalCorePackage) && !$this->checkScaffoldFiles()) {
+    if (isset($this->drupalCorePackage) && $this->checkAction($event)) {
       $this->downloadScaffold();
     }
   }
 
   /**
-   * Post update command event to execute the scaffolding.
-   *
-   * @param \Composer\Script\Event $event
+   * Return 'TRUE' if the download scaffold action should be done.
    */
-  public function onPostUpdateCmdEvent(\Composer\Script\Event $event) {
-    // Trigger scaffold downloads every time the drupal core package is updated
-    if (isset($this->drupalCorePackage)) {
-      $this->downloadScaffold();
-    }
-  }
+  public function checkAction(\Composer\Script\Event $event) {
+    // TODO: check options based on $event->getName()
+    $options = $this->getOptions();
 
-  /**
-   * Return 'TRUE' if there are any scaffold files present.
-   *
-   * (Alternatively, rule could be to return TRUE if all
-   * of the scaffold files and directories are present, but
-   * in the case of includes with a glob pattern, this could be
-   * a problem.)
-   */
-  public function checkScaffoldFiles() {
-    $drupalCorePackage = $this->getDrupalCorePackage();
-    $installationManager = $this->composer->getInstallationManager();
-    $corePath = $installationManager->getInstallPath($drupalCorePackage);
-    // Webroot is the parent path of the drupal core installation path.
-    $webroot = dirname($corePath);
-    $includes = $this->getIncludes();
-
-    foreach ($includes as $include) {
-      if (is_file("$webroot/$include")) {
-        return TRUE;
-      }
-    }
-
-    return FALSE;
+    return TRUE;
   }
 
   /**

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -200,10 +200,10 @@ class Handler {
       'LICENSE.txt',
       'README.txt',
       'vendor',
-      'sites',
       'themes',
       'profiles',
       'modules',
+      'sites/*',
     ];
   }
 
@@ -212,6 +212,8 @@ class Handler {
    */
   protected function getIncludesDefault() {
     return [
+      'sites',
+      'sites/default',
       'sites/default/default.settings.php',
       'sites/default/default.services.yml',
       'sites/development.services.yml',

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -87,7 +87,7 @@ class Handler {
     // Collect options, excludes and settings files.
     $options = $this->getOptions();
     $excludes = $this->getExcludes();
-    $settingsFiles = $this->getSettingsFiles();
+    $includes = $this->getIncludes();
 
     // Run Robo
     $robo = new RoboRunner();
@@ -102,8 +102,8 @@ class Handler {
         $webroot,
         '--excludes',
         implode(RoboFile::DELIMITER_EXCLUDE, $excludes),
-        '--settings',
-        implode(RoboFile::DELIMITER_EXCLUDE, $settingsFiles),
+        '--includes',
+        implode(RoboFile::DELIMITER_EXCLUDE, $includes),
       ]
     );
   }
@@ -147,8 +147,8 @@ class Handler {
    *
    * @return array
    */
-  protected function getSettingsFiles() {
-    return $this->getNamedOptionList('settings', 'getSettingFilesDefault');
+  protected function getIncludes() {
+    return $this->getNamedOptionList('includes', 'getIncludesDefault');
   }
 
   /**
@@ -179,7 +179,7 @@ class Handler {
     $options = $extra['drupal-scaffold'] + [
       'omit-defaults' => FALSE,
       'excludes' => [],
-      'settings' => [],
+      'includes' => [],
       'source' => 'http://ftp.drupal.org/files/projects/drupal-{version}.tar.gz',
     ];
     return $options;
@@ -210,7 +210,7 @@ class Handler {
   /**
    * Holds default settings files list.
    */
-  protected function getSettingFilesDefault() {
+  protected function getIncludesDefault() {
     return [
       'sites/default/default.settings.php',
       'sites/default/default.services.yml',

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -84,41 +84,28 @@ class Handler {
     // Webroot is the parent path of the drupal core installation path.
     $webroot = dirname($corePath);
 
-    // Collect excludes and settings files.
+    // Collect options, excludes and settings files.
+    $options = $this->getOptions();
     $excludes = $this->getExcludes();
     $settingsFiles = $this->getSettingsFiles();
 
-    // Fetch options, and pass values to Robo based on the method
-    // selected to download the scaffold files.
-    $options = $this->getOptions();
-    $extra = [];
-    switch ($options['method']) {
-      case 'drush':
-        $roboCommand = 'drupal_scaffold:drush-download';
-        $extra = ['--drush', $this->getDrushDir() . '/drush'];
-        break;
-      case 'http':
-        $roboCommand = 'drupal_scaffold:http-download';
-        $extra = ['--source', $options['source']];
-        break;
-    }
-
     // Run Robo
     $robo = new RoboRunner();
-    $robo->execute(array_merge(
+    $robo->execute(
       [
         'robo',
-        $roboCommand,
+        'drupal_scaffold:download',
         $drupalCorePackage->getPrettyVersion(),
+        '--source',
+        $options['source'],
         '--webroot',
         $webroot,
         '--excludes',
         implode(RoboFile::DELIMITER_EXCLUDE, $excludes),
         '--settings',
         implode(RoboFile::DELIMITER_EXCLUDE, $settingsFiles),
-      ],
-      $extra
-    ));
+      ]
+    );
   }
 
   /**
@@ -132,19 +119,6 @@ class Handler {
       $this->drupalCorePackage = $this->getPackage('drupal/core');
     }
     return $this->drupalCorePackage;
-  }
-
-  /**
-   * Helper to get the drush directory.
-   *
-   * @return string
-   *   The absolute path for the drush directory.
-   */
-  public function getDrushDir() {
-    $package = $this->getPackage('drush/drush');
-    if ($package) {
-      return $this->composer->getInstallationManager()->getInstallPath($package);
-    }
   }
 
   /**
@@ -206,7 +180,6 @@ class Handler {
       'omit-defaults' => FALSE,
       'excludes' => [],
       'settings' => [],
-      'method' => 'drush',
       'source' => 'http://ftp.drupal.org/files/projects/drupal-{version}.tar.gz',
     ];
     return $options;

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -241,6 +241,7 @@ class Handler {
     return [
       'sites/default/default.settings.php',
       'sites/default/default.services.yml',
+      'sites/development.services.yml',
       'sites/example.settings.local.php',
       'sites/example.sites.php'
     ];

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -44,8 +44,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
       PackageEvents::POST_PACKAGE_INSTALL => 'postPackage',
       PackageEvents::POST_PACKAGE_UPDATE => 'postPackage',
       //PackageEvents::POST_PACKAGE_UNINSTALL => 'postPackage',
-      ScriptEvents::POST_INSTALL_CMD => 'postCmd',
-      ScriptEvents::POST_UPDATE_CMD => 'postCmd',
+      ScriptEvents::POST_INSTALL_CMD => 'postInstallCmd',
+      ScriptEvents::POST_UPDATE_CMD => 'postUpdateCmd',
     );
   }
 
@@ -63,8 +63,17 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
    *
    * @param \Composer\Script\Event $event
    */
-  public function postCmd(\Composer\Script\Event $event) {
-    $this->handler->onPostCmdEvent($event);
+  public function postInstallCmd(\Composer\Script\Event $event) {
+    $this->handler->onPostInstallCmdEvent($event);
+  }
+
+  /**
+   * Post command event callback.
+   *
+   * @param \Composer\Script\Event $event
+   */
+  public function postUpdateCmd(\Composer\Script\Event $event) {
+    $this->handler->onPostUpdateCmdEvent($event);
   }
 
   /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -44,8 +44,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
       PackageEvents::POST_PACKAGE_INSTALL => 'postPackage',
       PackageEvents::POST_PACKAGE_UPDATE => 'postPackage',
       //PackageEvents::POST_PACKAGE_UNINSTALL => 'postPackage',
-      ScriptEvents::POST_INSTALL_CMD => 'postInstallCmd',
-      ScriptEvents::POST_UPDATE_CMD => 'postUpdateCmd',
+      ScriptEvents::POST_INSTALL_CMD => 'postCmd',
+      ScriptEvents::POST_UPDATE_CMD => 'postCmd',
     );
   }
 
@@ -63,17 +63,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
    *
    * @param \Composer\Script\Event $event
    */
-  public function postInstallCmd(\Composer\Script\Event $event) {
-    $this->handler->onPostInstallCmdEvent($event);
-  }
-
-  /**
-   * Post command event callback.
-   *
-   * @param \Composer\Script\Event $event
-   */
-  public function postUpdateCmd(\Composer\Script\Event $event) {
-    $this->handler->onPostUpdateCmdEvent($event);
+  public function postCmd(\Composer\Script\Event $event) {
+    $this->handler->onPostCmdEvent($event);
   }
 
   /**

--- a/src/RoboFile.php
+++ b/src/RoboFile.php
@@ -85,14 +85,19 @@ class RoboFile extends \Robo\Tasks {
     $tmpDir = $this->getTmpDir();
     $archiveName = basename($source);
     $archivePath = "$tmpDir/$archiveName";
-    // $archiveExtension = preg_match("#\.[a-z.]*$#", $archiveName, $matches);
+    $fetchDirName = $this->getFetchDirName();
 
     // Gets the source via wget.
     $fetch = $this->taskExec('wget')
       ->args($source)
       ->args("--output-file=$archivePath");
 
-    return $this->fetchAndPlaceScaffold($webroot, $tmpDir, $excludes, $settingsFiles, [$fetch]);
+    // Once this is merged into Robo, we will be able to simply do:
+    // $extract = $this->tastExtract($archivePath)->to("$tmpDir/$fetchDirName");
+    $extract = new Extract($archivePath);
+    $extract->to("$tmpDir/$fetchDirName");
+
+    return $this->fetchAndPlaceScaffold($webroot, $tmpDir, $excludes, $settingsFiles, [$fetch, $extract]);
   }
 
   protected function fetchAndPlaceScaffold($webroot, $tmpDir, $excludes, $settingsFiles, $ops) {
@@ -143,130 +148,5 @@ class RoboFile extends \Robo\Tasks {
     $this->taskFilesystemStack()
       ->chmod($confDir, $confDirOriginalPerms)
       ->run();
-  }
-
-  protected function extractArchive($archivePath, $destination) {
-    if (!($mimetype = $this->archiveType($archivePath))) {
-      return;
-    }
-
-    // We will first extract to $extractLocation and then move to $destination
-    $extractLocation = $this->getTmpDir();
-    $this->taskFilesystemStack()
-      ->mkdir($extractLocation)
-      ->mkdir(dirname($destination))
-      ->run();
-
-    // Perform the extraction of a zip file.
-    if (($mimetype == 'application/zip') || ($mimetype == 'application/x-zip')) {
-      $this->taskExec("unzip")
-        ->args($archivePath)
-        ->args("-d")
-        ->args("--destination=$extractLocation")
-        ->run();
-    }
-    // Otherwise we have a possibly-compressed Tar file.
-    // If we are not on Windows, then try to do "tar" in a single operation.
-    else {
-      $tar_compression_flag = '';
-      if ($mimetype == 'application/x-gzip') {
-        $tar_compression_flag = 'z';
-      }
-      elseif ($mimetype == 'application/x-bzip2') {
-        $tar_compression_flag = 'j';
-      }
-      $this->taskExec("tar")
-        ->args('-C')
-        ->args($extractLocation)
-        ->args("-x${$tar_compression_flag}f")
-        ->args($archivePath)
-        ->run();
-    }
-
-    // Now, we want to move the extracted files to $destination. There
-    // are two possibilities that we must consider:
-    //
-    // (1) Archived files were encapsulated in a folder with an arbitrary name
-    // (2) There was no encapsulating folder, and all the files in the archive
-    //     were extracted into $extractLocation
-    //
-    // In the case of (1), we want to move and rename the encapsulating folder
-    // to $destination.
-    //
-    // In the case of (2), we will just move and rename $extractLocation.
-    $filesInExtractLocation = glob("$extractLocation/*");
-    $hasEncapsulatingFolder = ((count($filesInExtractLocation) == 1) && is_dir($filesInExtractLocation[0]));
-    if ($hasEncapsulatingFolder) {
-      $this->taskFilesystemStack()
-        ->rename($filesInExtractLocation[0], $destination);
-      $this->taskDeleteDir($extractLocation)->run();
-    }
-    else {
-      $this->taskFilesystemStack()
-        ->rename($extractLocation, $destination);
-    }
-    return $return;
-  }
-
-  protected function archiveType($archivePath) {
-    $content_type = FALSE;
-    if (class_exists('finfo')) {
-      $finfo = new finfo(FILEINFO_MIME_TYPE);
-      $content_type = $finfo->file($filename);
-      // If finfo cannot determine the content type, then we will try other methods
-      if ($content_type == 'application/octet-stream') {
-        $content_type = FALSE;
-      }
-    }
-    // Examing the file's magic header bytes.
-    if (!$content_type) {
-      if ($file = fopen($filename, 'rb')) {
-        $first = fread($file, 2);
-        fclose($file);
-
-        if ($first !== FALSE) {
-          // Interpret the two bytes as a little endian 16-bit unsigned int.
-          $data = unpack('v', $first);
-          switch ($data[1]) {
-            case 0x8b1f:
-              // First two bytes of gzip files are 0x1f, 0x8b (little-endian).
-              // See http://www.gzip.org/zlib/rfc-gzip.html#header-trailer
-              $content_type = 'application/x-gzip';
-              break;
-
-            case 0x4b50:
-              // First two bytes of zip files are 0x50, 0x4b ('PK') (little-endian).
-              // See http://en.wikipedia.org/wiki/Zip_(file_format)#File_headers
-              $content_type = 'application/zip';
-              break;
-
-            case 0x5a42:
-              // First two bytes of bzip2 files are 0x5a, 0x42 ('BZ') (big-endian).
-              // See http://en.wikipedia.org/wiki/Bzip2#File_format
-              $content_type = 'application/x-bzip2';
-              break;
-          }
-        }
-      }
-    }
-    // 3. Lastly if above methods didn't work, try to guess the mime type from
-    // the file extension. This is useful if the file has no identificable magic
-    // header bytes (for example tarballs).
-    if (!$content_type) {
-      // Remove querystring from the filename, if present.
-      $filename = basename(current(explode('?', $filename, 2)));
-      $extension_mimetype = array(
-        '.tar.gz'  => 'application/x-gzip',
-        '.tgz'     => 'application/x-gzip',
-        '.tar'     => 'application/x-tar',
-      );
-      foreach ($extension_mimetype as $extension => $ct) {
-        if (substr($filename, -strlen($extension)) === $extension) {
-          $content_type = $ct;
-          break;
-        }
-      }
-    }
-    return $content_type;
   }
 }

--- a/src/RoboFile.php
+++ b/src/RoboFile.php
@@ -17,27 +17,87 @@ class RoboFile extends \Robo\Tasks {
    * @return string
    */
   protected function getTmpDir() {
-    return getcwd() . '/tmp' . time();
+    return getcwd() . '/tmp' . rand() . time();
   }
 
   /**
-   * Downloads
-   * @param null $version
+   * Decide what our fetch directory should be named
+   * (temporary location to stash scaffold files before
+   * moving them to their final destination in the project).
+   *
+   * @return string
+   */
+  protected function getFetchDirName() {
+    return 'drupal-8';
+  }
+
+  /**
+   * Download scaffold files using Drush
+   * @param string $version
    *
    * @param array $options
-   *   Additional options to override path to rush and webroot.
+   *   Additional options to override path to drush and webroot.
    */
-  public function drupal_scaffoldDownload($version = '8', $options = array(
+  public function drupal_scaffoldDrushDownload($version = '8', $options = array(
     'drush' => 'vendor/bin/drush',
     'webroot' => 'web',
     'excludes' => '',
+    'settings' => '',
   )) {
 
     $drush = $options['drush'];
     $webroot = $options['webroot'];
     $excludes = array_filter(explode(static::DELIMITER_EXCLUDE, $options['excludes']));
+    $settingsFiles = array_filter(explode(static::DELIMITER_EXCLUDE, $options['settings']));
     $tmpDir = $this->getTmpDir();
+    $fetchDirName = $this->getFetchDirName();
+
+    // Gets the source via drush.
+    $fetch = $this->taskExec($drush)
+      ->args(['dl', 'drupal-' . $version])
+      ->args("--root=$tmpDir")
+      ->args("--destination=$tmpDir")
+      ->args("--drupal-project-rename=$fetchDirName")
+      ->args('--quiet')
+      ->args('--yes');
+
+    return $this->fetchAndPlaceScaffold($webroot, $tmpDir, $excludes, $settingsFiles, [$fetch]);
+  }
+
+  /**
+   * Download scaffold files using Http
+   * @param string $version
+   *
+   * @param array $options
+   *   Additional options to override path to webroot and download url.
+   */
+  public function drupal_scaffoldHttpDownload($version = '8', $options = array(
+    'source' => 'http://ftp.drupal.org/files/projects/drupal-{version}.tar.gz',
+    'webroot' => 'web',
+    'excludes' => '',
+    'settings' => '',
+  )) {
+
+    $source = str_replace('{version}', $version, $options['source']);
+    $webroot = $options['webroot'];
+    $excludes = array_filter(explode(static::DELIMITER_EXCLUDE, $options['excludes']));
+    $settingsFiles = array_filter(explode(static::DELIMITER_EXCLUDE, $options['settings']));
+    $tmpDir = $this->getTmpDir();
+    $archiveName = basename($source);
+    $archivePath = "$tmpDir/$archiveName";
+    // $archiveExtension = preg_match("#\.[a-z.]*$#", $archiveName, $matches);
+
+    // Gets the source via wget.
+    $fetch = $this->taskExec('wget')
+      ->args($source)
+      ->args("--output-file=$archivePath");
+
+    return $this->fetchAndPlaceScaffold($webroot, $tmpDir, $excludes, $settingsFiles, [$fetch]);
+  }
+
+  protected function fetchAndPlaceScaffold($webroot, $tmpDir, $excludes, $settingsFiles, $ops) {
     $confDir = $webroot . '/sites/default';
+    $fetchDirName = $this->getFetchDirName();
 
     $this->stopOnFail();
 
@@ -52,18 +112,14 @@ class RoboFile extends \Robo\Tasks {
     $this->taskCleanDir([$tmpDir])
       ->run();
 
-    // Gets the source via drush.
-    $this->taskExec($drush)
-      ->args(['dl', 'drupal-' . $version])
-      ->args("--root=$tmpDir")
-      ->args("--destination=$tmpDir")
-      ->args('--drupal-project-rename=drupal-8')
-      ->args('--quiet')
-      ->args('--yes')
-      ->run();
+    // Gets the source and extrat, if necessary
+    foreach ($ops as $op) {
+      $fetch->run();
+    }
 
+    // Place scaffold files where they belong in the destination
     $rsync = $this->taskRsync()
-      ->fromPath("$tmpDir/drupal-8/")
+      ->fromPath("$tmpDir/$fetchDirName/")
       ->toPath($webroot)
       ->args('-a', '-v', '-z')
       ->args('--delete');
@@ -72,26 +128,145 @@ class RoboFile extends \Robo\Tasks {
     }
     $rsync->run();
 
-    $default_settings = [
-      'sites/default/default.settings.php',
-      'sites/default/default.services.yml',
-      'sites/example.settings.local.php',
-      'sites/example.sites.php'
-    ];
-
-    foreach ($default_settings as $file) {
+    // Place any additional listed settings files
+    // (e.g. sites/default/example.settings.php)
+    foreach ($settingsFiles as $file) {
       $this->taskRsync()
-        ->fromPath("$tmpDir/drupal-8/" . $file)
+        ->fromPath("$tmpDir/$fetchDirName/" . $file)
         ->toPath($webroot . '/' . $file)
         ->run();
     }
 
+    // Clean up
     $this->taskDeleteDir($tmpDir)
       ->run();
-
     $this->taskFilesystemStack()
       ->chmod($confDir, $confDirOriginalPerms)
       ->run();
   }
 
+  protected function extractArchive($archivePath, $destination) {
+    if (!($mimetype = $this->archiveType($archivePath))) {
+      return;
+    }
+
+    // We will first extract to $extractLocation and then move to $destination
+    $extractLocation = $this->getTmpDir();
+    $this->taskFilesystemStack()
+      ->mkdir($extractLocation)
+      ->mkdir(dirname($destination))
+      ->run();
+
+    // Perform the extraction of a zip file.
+    if (($mimetype == 'application/zip') || ($mimetype == 'application/x-zip')) {
+      $this->taskExec("unzip")
+        ->args($archivePath)
+        ->args("-d")
+        ->args("--destination=$extractLocation")
+        ->run();
+    }
+    // Otherwise we have a possibly-compressed Tar file.
+    // If we are not on Windows, then try to do "tar" in a single operation.
+    else {
+      $tar_compression_flag = '';
+      if ($mimetype == 'application/x-gzip') {
+        $tar_compression_flag = 'z';
+      }
+      elseif ($mimetype == 'application/x-bzip2') {
+        $tar_compression_flag = 'j';
+      }
+      $this->taskExec("tar")
+        ->args('-C')
+        ->args($extractLocation)
+        ->args("-x${$tar_compression_flag}f")
+        ->args($archivePath)
+        ->run();
+    }
+
+    // Now, we want to move the extracted files to $destination. There
+    // are two possibilities that we must consider:
+    //
+    // (1) Archived files were encapsulated in a folder with an arbitrary name
+    // (2) There was no encapsulating folder, and all the files in the archive
+    //     were extracted into $extractLocation
+    //
+    // In the case of (1), we want to move and rename the encapsulating folder
+    // to $destination.
+    //
+    // In the case of (2), we will just move and rename $extractLocation.
+    $filesInExtractLocation = glob("$extractLocation/*");
+    $hasEncapsulatingFolder = ((count($filesInExtractLocation) == 1) && is_dir($filesInExtractLocation[0]));
+    if ($hasEncapsulatingFolder) {
+      $this->taskFilesystemStack()
+        ->rename($filesInExtractLocation[0], $destination);
+      $this->taskDeleteDir($extractLocation)->run();
+    }
+    else {
+      $this->taskFilesystemStack()
+        ->rename($extractLocation, $destination);
+    }
+    return $return;
+  }
+
+  protected function archiveType($archivePath) {
+    $content_type = FALSE;
+    if (class_exists('finfo')) {
+      $finfo = new finfo(FILEINFO_MIME_TYPE);
+      $content_type = $finfo->file($filename);
+      // If finfo cannot determine the content type, then we will try other methods
+      if ($content_type == 'application/octet-stream') {
+        $content_type = FALSE;
+      }
+    }
+    // Examing the file's magic header bytes.
+    if (!$content_type) {
+      if ($file = fopen($filename, 'rb')) {
+        $first = fread($file, 2);
+        fclose($file);
+
+        if ($first !== FALSE) {
+          // Interpret the two bytes as a little endian 16-bit unsigned int.
+          $data = unpack('v', $first);
+          switch ($data[1]) {
+            case 0x8b1f:
+              // First two bytes of gzip files are 0x1f, 0x8b (little-endian).
+              // See http://www.gzip.org/zlib/rfc-gzip.html#header-trailer
+              $content_type = 'application/x-gzip';
+              break;
+
+            case 0x4b50:
+              // First two bytes of zip files are 0x50, 0x4b ('PK') (little-endian).
+              // See http://en.wikipedia.org/wiki/Zip_(file_format)#File_headers
+              $content_type = 'application/zip';
+              break;
+
+            case 0x5a42:
+              // First two bytes of bzip2 files are 0x5a, 0x42 ('BZ') (big-endian).
+              // See http://en.wikipedia.org/wiki/Bzip2#File_format
+              $content_type = 'application/x-bzip2';
+              break;
+          }
+        }
+      }
+    }
+    // 3. Lastly if above methods didn't work, try to guess the mime type from
+    // the file extension. This is useful if the file has no identificable magic
+    // header bytes (for example tarballs).
+    if (!$content_type) {
+      // Remove querystring from the filename, if present.
+      $filename = basename(current(explode('?', $filename, 2)));
+      $extension_mimetype = array(
+        '.tar.gz'  => 'application/x-gzip',
+        '.tgz'     => 'application/x-gzip',
+        '.tar'     => 'application/x-tar',
+      );
+      foreach ($extension_mimetype as $extension => $ct) {
+        if (substr($filename, -strlen($extension)) === $extension) {
+          $content_type = $ct;
+          break;
+        }
+      }
+    }
+    return $content_type;
+  }
 }

--- a/src/RoboFile.php
+++ b/src/RoboFile.php
@@ -42,14 +42,14 @@ class RoboFile extends \Robo\Tasks {
     'source' => 'http://ftp.drupal.org/files/projects/drupal-{version}.tar.gz',
     'webroot' => 'web',
     'excludes' => '',
-    'settings' => '',
+    'includes' => '',
   )) {
 
     $source = str_replace('{version}', $version, $options['source']);
     $webroot = $options['webroot'];
     $confDir = $webroot . '/sites/default';
     $excludes = array_filter(explode(static::DELIMITER_EXCLUDE, $options['excludes']));
-    $settingsFiles = array_filter(explode(static::DELIMITER_EXCLUDE, $options['settings']));
+    $includes = array_filter(explode(static::DELIMITER_EXCLUDE, $options['includes']));
     $tmpDir = $this->getTmpDir();
     $archiveName = basename($source);
     $archivePath = "$tmpDir/$archiveName";
@@ -99,7 +99,7 @@ class RoboFile extends \Robo\Tasks {
 
     // Place any additional listed settings files
     // (e.g. sites/default/example.settings.php)
-    foreach ($settingsFiles as $file) {
+    foreach ($includes as $file) {
       $this->taskRsync()
         ->fromPath("$tmpDir/$fetchDirName/" . $file)
         ->toPath($webroot . '/' . $file)

--- a/src/RoboFile.php
+++ b/src/RoboFile.php
@@ -90,21 +90,14 @@ class RoboFile extends \Robo\Tasks {
     $rsync = $this->taskRsync()
       ->fromPath("$tmpDir/$fetchDirName/")
       ->toPath($webroot)
-      ->args('-a', '-v', '-z')
-      ->args('--delete');
+      ->args('-a', '-v', '-z');
+    foreach ($includes as $include) {
+      $rsync->option('include', escapeshellarg($include));
+    }
     foreach ($excludes as $exclude) {
       $rsync->exclude($exclude);
     }
     $rsync->run();
-
-    // Place any additional listed settings files
-    // (e.g. sites/default/example.settings.php)
-    foreach ($includes as $file) {
-      $this->taskRsync()
-        ->fromPath("$tmpDir/$fetchDirName/" . $file)
-        ->toPath($webroot . '/' . $file)
-        ->run();
-    }
 
     // Clean up
     $this->taskDeleteDir($tmpDir)

--- a/src/RoboFile.php
+++ b/src/RoboFile.php
@@ -107,11 +107,17 @@ class RoboFile extends \Robo\Tasks {
 
     $this->stopOnFail();
 
-    $confDirOriginalPerms = fileperms($confDir);
+    $confDirOriginalPerms = FALSE;
+    if (is_dir($confDir)) {
+      $confDirOriginalPerms = fileperms($confDir);
+      $this->taskFilesystemStack()
+        ->chmod($confDir, 0755)
+        ->run();
+    }
 
     $this->taskFilesystemStack()
       ->mkdir($tmpDir)
-      ->chmod($confDir, 0755)
+      ->mkdir($confDir)
       ->run();
 
     // Make sure we have an empty temp dir.
@@ -146,8 +152,10 @@ class RoboFile extends \Robo\Tasks {
     // Clean up
     $this->taskDeleteDir($tmpDir)
       ->run();
-    $this->taskFilesystemStack()
-      ->chmod($confDir, $confDirOriginalPerms)
-      ->run();
+    if ($confDirOriginalPerms) {
+      $this->taskFilesystemStack()
+        ->chmod($confDir, $confDirOriginalPerms)
+        ->run();
+    }
   }
 }

--- a/src/RoboFile.php
+++ b/src/RoboFile.php
@@ -90,7 +90,8 @@ class RoboFile extends \Robo\Tasks {
     // Gets the source via wget.
     $fetch = $this->taskExec('wget')
       ->args($source)
-      ->args("--output-file=$archivePath");
+      ->args("--output-file=/dev/null")
+      ->args("--output-document=$archivePath");
 
     // Once this is merged into Robo, we will be able to simply do:
     // $extract = $this->tastExtract($archivePath)->to("$tmpDir/$fetchDirName");

--- a/src/RoboFile.php
+++ b/src/RoboFile.php
@@ -114,7 +114,7 @@ class RoboFile extends \Robo\Tasks {
 
     // Gets the source and extrat, if necessary
     foreach ($ops as $op) {
-      $fetch->run();
+      $op->run();
     }
 
     // Place scaffold files where they belong in the destination


### PR DESCRIPTION
This PR allows the user to choose between `http` and `drush` download methods.  The use-case for http is when the user wishes to use a custom set of scaffolding files not available via drush dl, e.g. pantheon-systems/drops-8.

It is my intention that the `Extract` class should eventually become part of Robo, but I have included it here for now so that this functionality can be implemented.