### PR TITLE
Fixes #11 (maybe): Use ZipArchive and Archive_Tar 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "require": {
         "php": ">=5.4.5",
         "composer-plugin-api": "^1.0.0",
+        "pear/archive_tar": "~1.0",
         "codegyre/robo": "^0.6.0"
     },
     "autoload": {

--- a/src/Extract.php
+++ b/src/Extract.php
@@ -45,25 +45,26 @@ class Extract extends BaseTask
     @mkdir($extractLocation);
     @mkdir(dirname($this->to));
 
+    $this->startTimer();
+
     // Perform the extraction of a zip file.
     if (($mimetype == 'application/zip') || ($mimetype == 'application/x-zip')) {
-      $command = "unzip {$this->filename} -d --destination=$extractLocation";
+      $this->printTaskInfo("Unzipping <info>{$this->filename}</info>");
+
+      $zip = new \ZipArchive();
+      if (($status = $zip->open($this->filename)) === TRUE) {
+        $zip->extractTo($extractLocation);
+        $zip->close();
+        $status = 0;
+      }
     }
     // Otherwise we have a possibly-compressed Tar file.
-    // If we are not on Windows, then try to do "tar" in a single operation.
     else {
-      $tar_compression_flag = '';
-      if ($mimetype == 'application/x-gzip') {
-        $tar_compression_flag = 'z';
-      }
-      elseif ($mimetype == 'application/x-bzip2') {
-        $tar_compression_flag = 'j';
-      }
-      $command = "tar -C $extractLocation -x{$tar_compression_flag}f {$this->filename}";
+      $this->printTaskInfo("Extracting <info>{$this->filename}</info>");
+      $tar_object = new \Archive_Tar($this->filename);
+      $tar_object->extract($extractLocation);
+      $status = 0;
     }
-    $this->printTaskInfo("Running <info>{$command}</info>");
-    $this->startTimer();
-    exec($command, $output, $status);
     $this->stopTimer();
     if ($status == 0) {
       // Now, we want to move the extracted files to $this->to. There


### PR DESCRIPTION
Rather than instead of exec'ing unzip and tar tools, this PR uses PHP libraries to do the same tasks.

ZipArchive requires ext-zip; Archive_Tar will work without PECL for .tar archive, but requires various extensions for different types of compressed tarballs.

Still needs testing on Windows, but in theory, should be completely cross-platform.