### PR TITLE
Fixes #9: Do not download the scaffold files after `composer install`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@ vendor directory.
 
 ## Usage
 
-`composer require drupal-composer/drupal-scaffold:dev-master` in your composer
+Run `composer require drupal-composer/drupal-scaffold:dev-master` in your composer
 project before installing or updating `drupal/core`.
+
+Once drupal-scaffold is required by your project, it will automatically update
+your scaffold files whenever `composer update` changes the version of
+`drupal/core` installed.
 
 ## Configuration
 
@@ -90,6 +94,8 @@ specifically, from the most recent development .tar.gz archive). This might
 not be what you want when using an old development version (e.g. when the
 version is fixed via composer.lock). To avoid problems, always commit your
 scaffold files to the repository any time that composer.lock is committed.
+Note that the correct scaffold files are retrieved when using a tagged release
+of `drupal/core` (recommended).
 
 ## Custom command
 
@@ -107,3 +113,9 @@ command callback to the `scripts`-section of your root `composer.json`, like thi
 
 After that you can manually download the scaffold files according to your
 configuration by using `composer drupal-scaffold`.
+
+Note that drupal-scaffold does not automatically run after `composer install`.
+It is assumed that the scaffold files will be committed to the repository, to
+ensure that the correct files are used on the CI server (see **Limitation**,
+above).  After running `composer install` for the first time, also run
+`composer drupal-scaffold`, and commit the scaffold files to your repository.

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -83,20 +83,11 @@ class Handler {
   public function onPostCmdEvent(\Composer\Script\Event $event) {
     // Only install the scaffolding if drupal/core was installed,
     // AND there are no scaffolding files present.
-    if (isset($this->drupalCorePackage) && $this->checkAction($event)) {
+    if (isset($this->drupalCorePackage)) {
       $this->downloadScaffold();
+      // Generate the autoload.php file after generating the scaffold files.
       $this->generateAutoload();
     }
-  }
-
-  /**
-   * Return 'TRUE' if the download scaffold action should be done.
-   */
-  public function checkAction(\Composer\Script\Event $event) {
-    // TODO: check options based on $event->getName()
-    $options = $this->getOptions();
-
-    return TRUE;
   }
 
   /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -44,7 +44,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
       PackageEvents::POST_PACKAGE_INSTALL => 'postPackage',
       PackageEvents::POST_PACKAGE_UPDATE => 'postPackage',
       //PackageEvents::POST_PACKAGE_UNINSTALL => 'postPackage',
-      ScriptEvents::POST_INSTALL_CMD => 'postCmd',
+      //ScriptEvents::POST_INSTALL_CMD => 'postCmd',
       ScriptEvents::POST_UPDATE_CMD => 'postCmd',
     );
   }
@@ -76,16 +76,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
   public static function scaffold(\Composer\Script\Event $event) {
     $handler = new Handler($event->getComposer(), $event->getIO());
     $handler->downloadScaffold();
-  }
-
-  /**
-   * Script callback for putting in composer scripts to generate the
-   * autoload file at the project root.
-   *
-   * @param \Composer\Script\Event $event
-   */
-  public static function generateAutoload(\Composer\Script\Event $event) {
-    $handler = new Handler($event->getComposer(), $event->getIO());
+    // Generate the autoload.php file after generating the scaffold files.
     $handler->generateAutoload();
   }
 }

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -69,7 +69,9 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
     $this->composer('install');
     $this->assertFileExists($this->tmpDir . DIRECTORY_SEPARATOR . 'core', 'Drupal core is installed.');
     $exampleScaffoldFile = $this->tmpDir . DIRECTORY_SEPARATOR . 'index.php';
-    $this->assertFileExists($exampleScaffoldFile, 'Scaffold file given.');
+    $this->assertFileNotExists($exampleScaffoldFile, 'Scaffold file should not be automatically installed.');
+    $this->composer('drupal-scaffold');
+    $this->assertFileExists($exampleScaffoldFile, 'Scaffold file should be installed by "drupal-scaffold" command.');
 
     // We touch a scaffold file, so we can check the file was modified after
     // the scaffold update.


### PR DESCRIPTION
With this PR, the scaffold files are only downloaded after `composer update`, or when explicitly requested.  See #9 for details.

I also changed the 'scaffold' custom command to always write the autoload.php file, since this should always be desired.  We could go back to making this a separate option, but then users would need two entries in their `scripts` section (one for scaffold, and one for autoload), and would need to call both operations to download the scaffold files the first time. This would be cumbersome, and the benefit of separation seems minimal to me.