### PR TITLE
Remove duplicate slashes in autoloader path

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -175,6 +175,8 @@ class Handler {
    * @return string
    */
   protected function autoLoadContents($relativeVendorPath) {
+    $relativeVendorPath = rtrim($relativeVendorPath, '/');
+
     $autoloadContents = <<<EOF
 <?php
 


### PR DESCRIPTION
Currently the auto generated ```autoload.php``` may contain a trailing slash for the ```$relativeVendorPath```variable. This results in duplicate slashes like this:

```return require __DIR__ . '/../vendor//autoload.php';```

This pull requests removes any trailing slashes from the variable