### PR TITLE
Fixes drupal-composer/drupal-project #111: Run robo via the RoboRunner

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -111,13 +111,12 @@ class Handler {
     $dispatcher->dispatch(self::PRE_DRUPAL_SCAFFOLD_CMD);
 
     // Run Robo
-    static::execute(
+    $robo = new RoboRunner();
+    $robo->execute(
       [
-        $this->getRoboExecutable(),
+        'robo',
         'drupal_scaffold:download',
         $drupalCorePackage->getPrettyVersion(),
-        '--load-from',
-        dirname(__DIR__) . "/scripts",
         '--source',
         $options['source'],
         '--webroot',

--- a/src/RoboFile.php
+++ b/src/RoboFile.php
@@ -103,10 +103,10 @@ class RoboFile extends \Robo\Tasks {
    * @param string $target
    */
   protected function downloadFile($source, $target) {
-    $this->say("Attempt to download $source to $target\n");
+    $this->say("Attempt to download $source to $target");
     $fp = fopen($target, 'w+');
     if (!$fp) {
-      $this->yell('Could not open target file ' . $target . "\n");
+      $this->yell('Could not open target file ' . $target);
       return false;
     }
     $ch = curl_init();
@@ -123,7 +123,7 @@ class RoboFile extends \Robo\Tasks {
     curl_close($ch);
 
     if (!array_key_exists('http_code', $details) || ($details['http_code'] != '200')) {
-      $this->yell('Could not download ' . $source . "\n");
+      $this->yell('Could not download ' . $source);
       return false;
     }
     return true;

--- a/src/RoboFile.php
+++ b/src/RoboFile.php
@@ -3,6 +3,7 @@
  * @file
  * Contains \RoboFile
  */
+namespace DrupalComposer\DrupalScaffold;
 
 use DrupalComposer\DrupalScaffold\Extract;
 
@@ -102,8 +103,30 @@ class RoboFile extends \Robo\Tasks {
    * @param string $target
    */
   protected function downloadFile($source, $target) {
-    $client = new \GuzzleHttp\Client(['base_uri' => dirname($source) . "/"]);
-    $response = $client->request('GET', basename($source), ['sink' => $target]);
+    $this->say("Attempt to download $source to $target\n");
+    $fp = fopen($target, 'w+');
+    if (!$fp) {
+      $this->yell('Could not open target file ' . $target . "\n");
+      return false;
+    }
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, $source);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 100);
+    curl_setopt($ch, CURLOPT_FORBID_REUSE, 1);
+    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
+    curl_setopt($ch, CURLOPT_FILE, $fp);
+    $result = curl_exec($ch);
+    fclose($fp);
+    $details = curl_getinfo($ch);
+    curl_close($ch);
+
+    if (!array_key_exists('http_code', $details) || ($details['http_code'] != '200')) {
+      $this->yell('Could not download ' . $source . "\n");
+      return false;
+    }
+    return true;
   }
 
 }


### PR DESCRIPTION
Run robo via the RoboRunner rather than exec; use php curl api instead of guzzle so this is possible. (Guzzle cannot be used from a Composer custom installer, because it requires autoloaded files, and Composer custom installers only autoload classes.)