### PR TITLE
Test composer install with lock file

### DIFF
--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -8,6 +8,7 @@
 namespace DrupalComposer\DrupalScaffold\Tests;
 
 use Composer\Util\Filesystem;
+use Symfony\Component\Finder\Finder;
 
 /**
  * Tests composer plugin functionality.
@@ -97,6 +98,24 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
     clearstatcache();
     $mtime_after = filemtime($exampleScaffoldFile);
     $this->assertNotEquals($mtime_after, $mtime_touched, 'Scaffold file was modified by custom command.');
+  }
+
+  /**
+   * Tests a simple composer install with composer.lock in place
+   */
+  public function testComposerInstallWithLock() {
+    // Prepare composer.lock file
+    $exampleScaffoldFile = $this->tmpDir . DIRECTORY_SEPARATOR . 'index.php';
+    $this->composer('install');
+    $finder = new Finder();
+    $finder->depth('== 0')->ignoreDotFiles(FALSE)->notName('/^composer\.(lock|json)$/')->in($this->tmpDir);
+    foreach ($finder as $file) {
+      $this->fs->remove($file->getRealPath());
+    }
+    $this->assertFileNotExists($exampleScaffoldFile, 'Scaffold file should not be exist.');
+    $this->composer('install');
+    $this->assertFileExists($this->tmpDir . DIRECTORY_SEPARATOR . 'core', 'Drupal core is installed.');
+    $this->assertFileExists($exampleScaffoldFile, 'Scaffold file should be automatically installed.');
   }
 
   /**


### PR DESCRIPTION
I'm not certain this is a bug but when running `composer install` for the first time on a project that has drupal-scaffold as a dependency then I would expect that drupal-scaffold by triggered. PluginTest::testComposerInstallAndUpdate confirms that having a `composer.json` file on it's on and running `composer install` will result in drupal-scaffold automatically being triggered. If, however, you have a composer.lock file present then `composer install` isn't sufficient to trigger drupal-scaffold.

I have added a test to prove this. But, it may be the expected behaviour, I'm not sure. If I run `composer drupal-scaffold` after `composer install` then my code is as I would expect it to be after running `composer install` for the first time.