### PR TITLE
Add an 'initial' element to the Drupal Scaffold 'extras' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ of your root `composer.json`.
       "includes": [
         "sites/default/example.settings.my.php"
       ],
+      "initial": {
+        "sites/default/default.services.yml": "sites/default/services.yml",
+        "sites/default/default.settings.php": "sites/default/settings.php"
+      },
       "omit-defaults": false
     }
   }
@@ -76,6 +80,10 @@ default includes will be provided; in this instance, only those files explicitly
 listed in the `excludes` and `includes` options will be considered. If
 `omit-defaults` is `false` (the default), then any items listed in `excludes`
 or `includes` will be in addition to the usual defaults.
+
+The `initial` hash lists files that should be copied over only if they do not
+exist in the destination. The key specifies the path to the source file, and
+the value indicates the path to the destination file.
 
 ## Limitation
 

--- a/src/FileFetcher.php
+++ b/src/FileFetcher.php
@@ -17,6 +17,10 @@ class FileFetcher {
    */
   protected $remoteFilesystem;
 
+  protected $source;
+  protected $filenames;
+  protected $fs;
+
   public function __construct(RemoteFilesystem $remoteFilesystem, $source, $filenames = []) {
     $this->remoteFilesystem = $remoteFilesystem;
     $this->source = $source;

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -114,8 +114,13 @@ class Handler {
       $version = substr($version, 0, -4);
     }
 
-    $fetcher = new FileFetcher(new RemoteFilesystem($this->io), $options['source'], $files);
+    $remoteFs = new RemoteFilesystem($this->io);
+
+    $fetcher = new FileFetcher($remoteFs, $options['source'], $files);
     $fetcher->fetch($version, $webroot);
+
+    $initialFileFetcher = new InitialFileFetcher($remoteFs, $options['source'], $this->getInitial());
+    $initialFileFetcher->fetch($version, $webroot);
 
     // Call post-scaffold scripts.
     $dispatcher->dispatch(self::POST_DRUPAL_SCAFFOLD_CMD);
@@ -240,6 +245,15 @@ EOF;
   }
 
   /**
+   * Retrieve list of initial files from optional "extra" configuration.
+   *
+   * @return array
+   */
+  protected function getInitial() {
+    return $this->getNamedOptionList('initial', 'getInitialDefault');
+  }
+
+  /**
    * Retrieve a named list of options from optional "extra" configuration.
    * Respects 'omit-defaults', and either includes or does not include the
    * default values, as requested.
@@ -268,6 +282,7 @@ EOF;
       'omit-defaults' => FALSE,
       'excludes' => [],
       'includes' => [],
+      'initial' => [],
       'source' => 'http://cgit.drupalcode.org/drupal/plain/{path}?h={version}',
       // Github: https://raw.githubusercontent.com/drupal/drupal/{version}/{path}
     ];
@@ -302,6 +317,13 @@ EOF;
       'update.php',
       'web.config'
     ];
+  }
+
+  /**
+   * Holds default initial files.
+   */
+  protected function getInitialDefault() {
+    return [];
   }
 
 }

--- a/src/InitialFileFetcher.php
+++ b/src/InitialFileFetcher.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Contains \DrupalComposer\DrupalScaffold\FileFetcher.
+ */
+
+namespace DrupalComposer\DrupalScaffold;
+
+use Composer\Util\Filesystem;
+use Composer\Util\RemoteFilesystem;
+
+class InitialFileFetcher extends FileFetcher {
+  public function fetch($version, $destination) {
+    array_walk($this->filenames, function ($filename, $sourceFilename) use ($version, $destination) {
+      $target = "$destination/$filename";
+      if (!file_exists($target)) {
+        $url = $this->getUri($sourceFilename, $version);
+        $this->fs->ensureDirectoryExists($destination . '/' . dirname($filename));
+        $this->remoteFilesystem->copy($url, $url, $target);
+      }
+    });
+  }
+}

--- a/tests/FetcherTest.php
+++ b/tests/FetcherTest.php
@@ -11,6 +11,7 @@ use Composer\IO\NullIO;
 use Composer\Util\Filesystem;
 use Composer\Util\RemoteFilesystem;
 use DrupalComposer\DrupalScaffold\FileFetcher;
+use DrupalComposer\DrupalScaffold\InitialFileFetcher;
 
 class FetcherTest extends \PHPUnit_Framework_TestCase {
 
@@ -67,4 +68,9 @@ class FetcherTest extends \PHPUnit_Framework_TestCase {
     $this->assertFileExists($this->tmpDir . '/sites/default/default.settings.php');
   }
 
+  public function testInitialFetch() {
+    $fetcher = new InitialFileFetcher(new RemoteFilesystem(new NullIO()), 'http://cgit.drupalcode.org/drupal/plain/{path}?h={version}', ['sites/default/default.settings.php' => 'sites/default/settings.php']);
+    $fetcher->fetch('8.1.1', $this->tmpDir);
+    $this->assertFileExists($this->tmpDir . '/sites/default/settings.php');
+  }
 }


### PR DESCRIPTION
This allow files to be scaffolded iff the target file does not yet exist (e.g. to copy from a default file to the user-customized file on first install only).

One important example of this is the settings.php file. In drops-8, Pantheon supplies an initial settings.php file; of course, Drupal makes this file read-only during the installation process. We want to be able to scaffold the settings.php file on the initial run, but on subsequent runs it would cause an error if we attempted to copy over this file.  Using the 'initial' files list introduced in this PR achieves this goal.