### PR TITLE
Support Drupal 8.3.x

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -301,11 +301,10 @@ EOF;
    * Holds default settings files list.
    */
   protected function getIncludesDefault() {
-    return [
+    $common = [
       '.csslintrc',
       '.editorconfig',
       '.eslintignore',
-      '.eslintrc',
       '.gitattributes',
       '.htaccess',
       'index.php',
@@ -318,6 +317,17 @@ EOF;
       'update.php',
       'web.config'
     ];
+
+    list($major, $minor) =  explode('.', \Drupal::VERSION, 3);
+    switch ("$major.$minor") {
+      case '8.3':
+        $addition = ['.eslintrc.json'];
+        break;
+      default:
+        $addition = ['.eslintrc'];
+    }
+
+    return array_merge($common, $addition);
   }
 
   /**


### PR DESCRIPTION
`.eslintrc` in Drupal =< 8.2.x became `.eslintrc.json` in Drupal 8.3.x. With the  current HEAD, when downloading scaffold files, a 404 is received trying to download the non-existing `.eslintrc` while `.eslintrc.json` is ignored.

I see two options:

1. To open a branch corresponding to Drupal 8.3.x but that would mean that existing projects should update their composer.json and also drupal-composer/drupal-project will have to maintain different branches for different Drupal minors.
1. Assure a single scaffold library regardless of what Drupal version is used, like Drush does.

In this PR I opted for the 2nd option.