### PR TITLE
Return true by default

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -77,6 +77,6 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
     $handler->downloadScaffold();
     // Generate the autoload.php file after generating the scaffold files.
     $handler->generateAutoload();
-    return true;
+    return 0;
   }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -77,5 +77,6 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
     $handler->downloadScaffold();
     // Generate the autoload.php file after generating the scaffold files.
     $handler->generateAutoload();
+    return true;
   }
 }


### PR DESCRIPTION
After you execute the command you don't get if is succeed or not. 

Because of this behavior some CI could think that is an error, so I propose to send true by default, if there is an error or exception won't reach the true so will be ok.