### PR TITLE
Download .ht.router.php on Drupal 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "license": "GPL-2.0+",
     "require": {
         "php": ">=5.4.5",
-        "composer-plugin-api": "^1.0.0"
+        "composer-plugin-api": "^1.0.0",
+        "composer/semver": "^1.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,71 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "116f69e7f88bcdebdc157a80dfaa31c7",
-    "content-hash": "fcbb0cf6a792bee4cd64b27b2e58909c",
-    "packages": [],
+    "content-hash": "84e81d56e7ed4144aee74f8da0745c4c",
+    "packages": [
+        {
+            "name": "composer/semver",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/c7cb9a2095a074d131b65a8a0cd294479d785573",
+                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5 || ^5.0.5",
+                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "time": "2016-08-30T16:08:34+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "composer/ca-bundle",
@@ -61,7 +123,7 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2016-04-13 10:13:24"
+            "time": "2016-04-13T10:13:24+00:00"
         },
         {
             "name": "composer/composer",
@@ -138,69 +200,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2016-05-19 18:44:43"
-        },
-        {
-            "name": "composer/semver",
-            "version": "1.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/semver.git",
-                "reference": "84c47f3d8901440403217afc120683c7385aecb8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/84c47f3d8901440403217afc120683c7385aecb8",
-                "reference": "84c47f3d8901440403217afc120683c7385aecb8",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.2 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.5 || ^5.0.5",
-                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Semver\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                },
-                {
-                    "name": "Rob Bast",
-                    "email": "rob.bast@gmail.com",
-                    "homepage": "http://robbast.nl"
-                }
-            ],
-            "description": "Semver library that offers utilities, version constraint parsing and validation.",
-            "keywords": [
-                "semantic",
-                "semver",
-                "validation",
-                "versioning"
-            ],
-            "time": "2016-03-30 13:16:03"
+            "time": "2016-05-19T18:44:43+00:00"
         },
         {
             "name": "composer/spdx-licenses",
@@ -261,7 +261,7 @@
                 "spdx",
                 "validator"
             ],
-            "time": "2016-05-04 12:27:30"
+            "time": "2016-05-04T12:27:30+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -315,7 +315,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -381,7 +381,7 @@
                 "json",
                 "schema"
             ],
-            "time": "2016-01-25 15:43:01"
+            "time": "2016-01-25T15:43:01+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -430,7 +430,7 @@
                     "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "time": "2015-02-03 12:10:50"
+            "time": "2015-02-03T12:10:50+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -492,7 +492,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-02-15 07:46:21"
+            "time": "2016-02-15T07:46:21+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -554,7 +554,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -601,7 +601,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2015-06-21T13:08:43+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -642,7 +642,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -686,7 +686,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2016-05-12T18:03:57+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -735,7 +735,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2015-09-15T10:49:45+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -807,7 +807,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-05-17 03:09:28"
+            "time": "2016-05-17T03:09:28+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -863,7 +863,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "psr/log",
@@ -901,7 +901,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2012-12-21 11:40:51"
+            "time": "2012-12-21T11:40:51+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -965,7 +965,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2015-07-26T15:48:44+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1017,7 +1017,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1067,7 +1067,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-05-17 03:18:57"
+            "time": "2016-05-17T03:18:57+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1133,7 +1133,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-06-21 07:55:53"
+            "time": "2015-06-21T07:55:53+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1184,7 +1184,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1237,7 +1237,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2015-11-11T19:50:13+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1272,7 +1272,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "seld/cli-prompt",
@@ -1320,7 +1320,7 @@
                 "input",
                 "prompt"
             ],
-            "time": "2016-04-18 09:31:41"
+            "time": "2016-04-18T09:31:41+00:00"
         },
         {
             "name": "seld/jsonlint",
@@ -1366,7 +1366,7 @@
                 "parser",
                 "validator"
             ],
-            "time": "2015-11-21 02:21:41"
+            "time": "2015-11-21T02:21:41+00:00"
         },
         {
             "name": "seld/phar-utils",
@@ -1410,7 +1410,7 @@
             "keywords": [
                 "phra"
             ],
-            "time": "2015-10-13 18:44:15"
+            "time": "2015-10-13T18:44:15+00:00"
         },
         {
             "name": "symfony/console",
@@ -1470,7 +1470,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-04-28 09:48:42"
+            "time": "2016-04-28T09:48:42+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -1519,7 +1519,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-04-12 18:09:53"
+            "time": "2016-04-12T18:09:53+00:00"
         },
         {
             "name": "symfony/finder",
@@ -1568,7 +1568,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-03-10 11:13:05"
+            "time": "2016-03-10T11:13:05+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1627,7 +1627,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-05-18T14:26:46+00:00"
         },
         {
             "name": "symfony/process",
@@ -1676,7 +1676,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-04-14 15:30:28"
+            "time": "2016-04-14T15:30:28+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -1725,7 +1725,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-03-04 07:55:57"
+            "time": "2016-03-04T07:55:57+00:00"
         }
     ],
     "aliases": [],

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -13,6 +13,7 @@ use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\EventDispatcher\EventDispatcher;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
+use Composer\Semver\Semver;
 use Composer\Util\Filesystem;
 use Composer\Util\RemoteFilesystem;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
@@ -327,7 +328,6 @@ EOF;
       '.csslintrc',
       '.editorconfig',
       '.eslintignore',
-      '.eslintrc.json',
       '.gitattributes',
       '.htaccess',
       'index.php',
@@ -342,13 +342,14 @@ EOF;
     ];
 
     // Version specific variations.
-    switch ($version) {
-      case '8.0':
-      case '8.1':
-      case '8.2':
-        $common[] = '.eslintrc';
-        $common = array_diff($common, ['.eslintrc.json']);
-        break;
+    if (Semver::satisfies($version, '<8.3')) {
+      $common[] = '.eslintrc';
+    }
+    if (Semver::satisfies($version, '>=8.3')) {
+      $common[] = '.eslintrc.json';
+    }
+    if (Semver::satisfies($version, '>=8.5')) {
+      $common[] = '.ht.router.php';
     }
 
     sort($common);

--- a/tests/FetcherTest.php
+++ b/tests/FetcherTest.php
@@ -69,28 +69,6 @@ class FetcherTest extends \PHPUnit_Framework_TestCase {
     $this->assertFileExists($this->tmpDir . '/sites/default/default.settings.php');
   }
 
-  /**
-   * Tests version specific files.
-   */
-  public function testFetchVersionSpecific() {
-    $fetcher = new FileFetcher(new RemoteFilesystem(new NullIO()), 'http://cgit.drupalcode.org/drupal/plain/{path}?h={version}', ['.eslintrc', '.eslintrc.json']);
-
-    $this->setExpectedException(TransportException::class);
-    $fetcher->fetch('8.2.x', $this->tmpDir);
-
-    $this->assertFileExists($this->tmpDir . '/.eslintrc');
-    $this->assertFileNotExists($this->tmpDir . '/.eslintrc.json');
-
-    // Remove downloaded files to retest with 8.3.x.
-    @unlink($this->tmpDir . '/.eslintrc');
-
-    $this->setExpectedException(TransportException::class);
-    $fetcher->fetch('8.3.x', $this->tmpDir);
-
-    $this->assertFileExists($this->tmpDir . '/.eslintrc.json');
-    $this->assertFileNotExists($this->tmpDir . '/.eslintrc');
-  }
-
   public function testInitialFetch() {
     $fetcher = new InitialFileFetcher(new RemoteFilesystem(new NullIO()), 'http://cgit.drupalcode.org/drupal/plain/{path}?h={version}', ['sites/default/default.settings.php' => 'sites/default/settings.php']);
     $fetcher->fetch('8.1.1', $this->tmpDir);

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -68,7 +68,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
   public function testComposerInstallAndUpdate() {
     $exampleScaffoldFile = $this->tmpDir . DIRECTORY_SEPARATOR . 'index.php';
     $this->assertFileNotExists($exampleScaffoldFile, 'Scaffold file should not be exist.');
-    $this->composer('install');
+    $this->composer('install --no-dev --prefer-dist');
     $this->assertFileExists($this->tmpDir . DIRECTORY_SEPARATOR . 'core', 'Drupal core is installed.');
     $this->assertFileExists($exampleScaffoldFile, 'Scaffold file should be automatically installed.');
     $this->fs->remove($exampleScaffoldFile);
@@ -76,16 +76,35 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
     $this->composer('drupal-scaffold');
     $this->assertFileExists($exampleScaffoldFile, 'Scaffold file should be installed by "drupal-scaffold" command.');
 
-    foreach (['8.0.1', '8.1.x-dev'] as $version) {
+    foreach (['8.0.1', '8.1.x-dev', '8.3.0', '8.5.x-dev'] as $version) {
       // We touch a scaffold file, so we can check the file was modified after
       // the scaffold update.
       touch($exampleScaffoldFile);
       $mtime_touched = filemtime($exampleScaffoldFile);
       // Requiring a newer version triggers "composer update"
-      $this->composer('require --update-with-dependencies drupal/core:"' . $version .'"');
+      $this->composer('require --update-with-dependencies --prefer-dist --update-no-dev drupal/core:"' . $version .'"');
       clearstatcache();
       $mtime_after = filemtime($exampleScaffoldFile);
       $this->assertNotEquals($mtime_after, $mtime_touched, 'Scaffold file was modified by composer update. (' . $version . ')');
+      switch ($version) {
+        case '8.0.1':
+        case '8.1.x-dev':
+          $this->assertFileExists($this->tmpDir . DIRECTORY_SEPARATOR . '.eslintrc');
+          $this->assertFileNotExists($this->tmpDir . DIRECTORY_SEPARATOR . '.eslintrc.json');
+          $this->assertFileNotExists($this->tmpDir . DIRECTORY_SEPARATOR . '.ht.router.php');
+          break;
+        case '8.3.0':
+          // Note we don't clean up .eslintrc file.
+          $this->assertFileExists($this->tmpDir . DIRECTORY_SEPARATOR . '.eslintrc');
+          $this->assertFileExists($this->tmpDir . DIRECTORY_SEPARATOR . '.eslintrc.json');
+          $this->assertFileNotExists($this->tmpDir . DIRECTORY_SEPARATOR . '.ht.router.php');
+          break;
+        case '8.5.x-dev':
+          $this->assertFileExists($this->tmpDir . DIRECTORY_SEPARATOR . '.eslintrc');
+          $this->assertFileExists($this->tmpDir . DIRECTORY_SEPARATOR . '.eslintrc.json');
+          $this->assertFileExists($this->tmpDir . DIRECTORY_SEPARATOR . '.ht.router.php');
+          break;
+      }
     }
 
     // We touch a scaffold file, so we can check the file was modified after


### PR DESCRIPTION
8.5 has a new file in the root directory: .ht.router.php so we need to download it.

Also testFetchVersionSpecific() does not test anything since the test exits after the first TransportException exception and never actually makes any assertions.

So added testing for the specific version files to testComposerInstallAndUpdate() and I've made this test a bit quicker by passing some options to the composer commands.