### PR TITLE
Parameter must be an array or an object that implements Countable

### DIFF
--- a/src/PrestissimoFileFetcher.php
+++ b/src/PrestissimoFileFetcher.php
@@ -55,6 +55,9 @@ class PrestissimoFileFetcher extends FileFetcher {
 
     $successCnt = $failureCnt = 0;
     $totalCnt = count($requests);
+    if ($totalCnt == 0) {
+      return;
+    }    
 
     $multi = new CurlMulti();
     $multi->setRequests($requests);


### PR DESCRIPTION
I received the following error when the scaffold was trying to download "initial" files during `composer install`, but they already exist and there are no curl requests to make.

```
Script DrupalComposer\DrupalScaffold\Plugin::scaffold handling the drupal-scaffold event terminated with an exception
[ErrorException]                                                            
  count(): Parameter must be an array or an object that implements Countable
```

This solves the problem by avoiding "curling" when there's nothing to curl.
The actual error is because curl never gets set up correctly and then when it gets to the `do while` in `fetchWithPrestissimo()`, `$multi->remain()` returns NULL (because it was never initialised).