### PR TITLE
Pre-load all of our sources on initial load 

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -56,6 +56,27 @@ class Handler {
     $this->composer = $composer;
     $this->io = $io;
     $this->progress = TRUE;
+
+    // Pre-load all of our sources so that we do not run up
+    // against problems in `composer update` operations.
+    $this->manualLoad();
+  }
+
+  protected function manualLoad() {
+    $src_dir = __DIR__;
+
+    $classes = [
+      'CommandProvider',
+      'DrupalScaffoldCommand',
+      'FileFetcher',
+      'PrestissimoFileFetcher',
+    ];
+
+    foreach ($classes as $src) {
+      if (!class_exists('\\DrupalComposer\\DrupalScaffold\\' . $src)) {
+        include "{$src_dir}/{$src}.php";
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
This ensures that we will not get a more recent version of one of our classes e.g. after a 'composer update' operation.

Still not sure if this is the best way, or if we should be more robust and `exec` every handler as considered in https://github.com/drupal-composer/drupal-scaffold/issues/79#issuecomment-395823865.

This is easier, and perhaps sufficient, so we'll start here. Still need to test the upgrade path.