### PR TITLE
Protect against missing result value

### DIFF
--- a/src/PrestissimoFileFetcher.php
+++ b/src/PrestissimoFileFetcher.php
@@ -68,7 +68,9 @@ class PrestissimoFileFetcher extends FileFetcher {
       $result = $multi->getFinishedResults();
       $successCnt += $result['successCnt'];
       $failureCnt += $result['failureCnt'];
-      $errors += $result['errors'];
+      if (isset($result['errors'])) {
+        $errors += $result['errors'];
+      }
       if ($this->progress) {
         foreach ($result['urls'] as $url) {
           $this->io->writeError("  - Downloading <comment>$successCnt</comment>/<comment>$totalCnt</comment>: <info>$url</info>", TRUE);


### PR DESCRIPTION
When running `composer drupal:scaffold` I was returned with the error 

```
[ErrorException]
  Undefined index: errors
```

Tracing through the problem it came to the `errors` key in the `$result`. It did not exist for me.

My setup

PHP: 7.1.20
drupal-composer/drupal-scaffold: 2.5.3
hirak/prestissimo: 0.3.6 (installed globally)
drupal/core: 8.5.5
Composer: 1.4.1