### PR TITLE
Fix typo in manual download command

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ command callback to the `scripts`-section of your root `composer.json`, like thi
 ```
 
 After that you can manually download the scaffold files according to your
-configuration by using `composer drupal-scaffold`.
+configuration by using `composer drupal:scaffold`.
 
 It is assumed that the scaffold files will be committed to the repository, to
 ensure that the correct files are used on the CI server (see **Limitation**,


### PR DESCRIPTION
Looks like the command given should use a colon rather than a hyphen:

[Symfony\Component\Console\Exception\CommandNotFoundException]
  Command "drupal-scaffold" is not defined.

  Did you mean this?
      drupal:scaffold