### PR TITLE
Add README.txt files to the scaffold (#89)

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -384,6 +384,10 @@ EOF;
       'sites/example.sites.php',
       'update.php',
       'web.config',
+      'modules/README.txt',
+      'profiles/README.txt',
+      'sites/README.txt',
+      'themes/README.txt',
     ];
 
     // Version specific variations.


### PR DESCRIPTION
### Issue links
#89

### Description
As requested in the issue #89 the following files has been added:

- modules/README.txt
- profiles/README.txt
- sites/README.txt
- themes/README.txt
